### PR TITLE
Add version DynamoDbClient connection

### DIFF
--- a/createtables.php
+++ b/createtables.php
@@ -5,7 +5,8 @@ require '/var/www/html/vendor/autoload.php';
 use Aws\DynamoDb\DynamoDbClient;
 
 $client = DynamoDbClient::factory(array(
-    'region' => 'eu-west-1'  // replace with your desired region
+    'region' => 'eu-west-1',  // replace with your desired region
+    'version' => '2012-08-10'
 ));
 
 $tableNames = array();


### PR DESCRIPTION
The previous code gives the following error:
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'Missing required client configuration options: 

version: (string)

  A "version" configuration value is required. Specifying a version constraint
  ensures that your code will not be affected by a breaking change made to the
  service. For example, when using Amazon S3, you can lock your API version to
  "2006-03-01".

  Your build of the SDK has the following version(s) of "dynamodb": \* "2012-08-10"

  You may provide "latest" to the "version" configuration value to utilize the
  most recent available API version that your client's API provider can find.
  Note: Using 'latest' in a production application is not recommended.

  A list of available API versions can be found on each client's API documentation
  page: http://docs.aws.amazon.com/aws-sdk-php/v3/api/index.html. If you are
  unable to load a specific API version, then you may need to update your copy of
  the SDK.' in /var/www/html/vendor/aws/aws-sdk-php/src/ClientResolver.php:328
St in /var/www/html/vendor/aws/aws-sdk-php/src/ClientResolver.php on line 328
